### PR TITLE
Tell the browser we're in dark-mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@ body {
 Styling darkmode globals
 */
 
+[data-color-mode="dark"] {
+  color-scheme: dark !important;
+}
+
 [data-color-mode="dark"] body {
   --color-bg-page: #1c1c20 !important;
   --color-bg-page-rgb: #1c1c20 !important;


### PR DESCRIPTION
This achieves dark scrollbars and other built-in elements while in our site's darkmode. Unbelievably readme doesn't do this automatically.