### PR TITLE
add css fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -591,6 +591,11 @@ Callout styling
   --emoji: unset;
 }
 
+.markdown-body .callout[theme="🌈"] > .callout-heading.empty {
+  float: none;
+  margin-top:0;
+}
+
 .markdown-body .callout[theme="🛝"] {
   background-origin: border-box;
   border: 0.125em solid transparent;


### PR DESCRIPTION
There is a bug with the spacing for callouts. See the callout on this page: https://developers.deepgram.com/docs/text-to-speech