### PR TITLE
fix margin on callouts

### DIFF
--- a/style.css
+++ b/style.css
@@ -75,7 +75,7 @@ Styling darkmode globals
 
 [data-color-mode="dark"] body {
   --color-text-default: #ededf2;
-  --color-link-default: #79AFFA;
+  --color-link-default: #79affa;
   --color-bg-page: #1c1c20;
   --color-bg-page-rgb: #1c1c20;
   --color-input-background: #000000;
@@ -156,7 +156,7 @@ DG classes
 .App .rdmd-html span.dg-badge,
 .App .rdmd-html a.dg-badge {
   margin-right: 6px;
-  color: #BBBBBF !important;
+  color: #bbbbbf !important;
   padding: 8px 16px;
   text-decoration: none;
   border-radius: 8px;
@@ -211,7 +211,7 @@ DG classes
 
 .App .rdmd-html span.dg-badge.language,
 .App .rdmd-html a.dg-badge.language {
-  background-image: linear-gradient(85deg, #EE028B 5.66%, #AE29FF 99.14%);
+  background-image: linear-gradient(85deg, #ee028b 5.66%, #ae29ff 99.14%);
 }
 
 .App .rdmd-html span.dg-badge.language::before,
@@ -283,10 +283,8 @@ Styling sidebar links.
 */
 
 [data-color-mode="dark"] body .rm-Sidebar-heading {
-  color: #B2D1FC;
+  color: #b2d1fc;
 }
-
-
 
 /**
 Override for "header-top" search button position.
@@ -515,6 +513,14 @@ Callout styling
   --text: var(--color-text-default);
 }
 
+.markdown-body .callout p {
+  margin-left: calc(1.75rem + 1.5rem);
+}
+
+.markdown-body .callout.callout .callout-heading {
+  margin-left: calc(1.75rem + 1.5rem);
+}
+
 .markdown-body .callout.callout_default {
   --background: var(--md-code-background);
   --title: var(--color-text-default);
@@ -524,12 +530,12 @@ Callout styling
 }
 
 .markdown-body .callout.callout_info {
-  --title: #149AFB;
+  --title: #149afb;
   --background: #1c2d44;
   --emoji: unset;
   --icon: "\f05a";
   --icon-color: var(--color-text-default);
-  border: solid #149AFB;
+  border: solid #149afb;
   border-width: 1px 1px 1px 3px;
   border-radius: 4px;
 }
@@ -593,7 +599,7 @@ Callout styling
 
 .markdown-body .callout[theme="🌈"] > .callout-heading.empty {
   float: none;
-  margin-top:0;
+  margin-top: 0;
 }
 
 .markdown-body .callout[theme="🛝"] {
@@ -731,17 +737,27 @@ body .rm-Sidebar-link[href="/reference/streaming"]::after {
 
 /* AI Bot Overrides */
 
-[data-color-mode="dark"] .tippy-box div[class*="ChatGPT"]  {
+[data-color-mode="dark"] .tippy-box div[class*="ChatGPT"] {
   background-image: none !important;
   box-shadow: 2px 10000px 1px #101014 inset !important;
   --md-code-background: #101014 !important;
 }
 
-[data-color-mode="dark"] .tippy-box div[class*="ChatGPT"] .CodeTabs-toolbar button {
+[data-color-mode="dark"]
+  .tippy-box
+  div[class*="ChatGPT"]
+  .CodeTabs-toolbar
+  button {
   color: #ededf2 !important;
 }
 
-[data-color-mode="dark"] .tippy-box div[class*="ChatGPT"] .CodeTabs .CodeTabs-inner pre code {
+[data-color-mode="dark"]
+  .tippy-box
+  div[class*="ChatGPT"]
+  .CodeTabs
+  .CodeTabs-inner
+  pre
+  code {
   color: #676e95 !important;
 }
 


### PR DESCRIPTION
The paragraph text alignment was off for callouts. I've added margin to improve it.

Problem:

<img width="904" alt="Screenshot 2024-07-15 at 10 23 33 AM" src="https://github.com/user-attachments/assets/299226c7-7e3c-482f-afc2-5411fb022fba">


Solution:

<img width="928" alt="Screenshot 2024-07-15 at 10 19 41 AM" src="https://github.com/user-attachments/assets/2097bb88-1603-415a-bf66-aa53ebf39389">

